### PR TITLE
Added PQ support to Trouper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 jobs:
   build:
     name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+### Version 1.0.2
+
+- Added Priority Queue Support to Trouper
+- Ability to declare a queue with maxPriority
+- Retry Queues (Since they work with TTLs) don't operate with priority but by default cascade the priority to the MQ
+- Sideline Publishes can be with a Priority, since consumers can be configured on a sideline. 
+
 ### Version 1.0.0
 
 - Moved to com.grookage from io.grookage.
 - Moved to java11 and dw 2.
-- Added sonar analysis 
+- Added sonar analysis
 
 ### Version 0.0.2
 
@@ -11,9 +18,13 @@
 
 ### Version 0.0.1-1
 
-- Added default handling to QTrouper.handle in case the properties object goes missing or when the headers are not present.
-- Doing a minor, for this is a bug fix. 
+- Added default handling to QTrouper.handle in case the properties object goes missing or when the
+  headers are not present.
+- Doing a minor, for this is a bug fix.
 
 ## Impact
 
-If you are using trouper to publish messages and read off it, this won't impact you. But when you are publishing messages using another RMQ client or an adhoc script that pushes messages into the queue without the headers, required (that trouper would've organically added), you'll see this issue. 
+If you are using trouper to publish messages and read off it, this won't impact you. But when you
+are publishing messages using another RMQ client or an adhoc script that pushes messages into the
+queue without the headers, required (that trouper would've organically added), you'll see this
+issue. 

--- a/README.md
+++ b/README.md
@@ -3,42 +3,47 @@
 > Do raindrops follow a certain hierarchy when they fall?
 > - by Anthony T. Hincks
 
-
 ### Maven Dependency
 
 Use the following maven dependency:
+
 ```xml
 <dependency>
     <groupId>com.grookage.qtrouper</groupId>
     <artifactId>qtrouper</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.2</version>
 </dependency>
 ```
 
 ### Build instructions
-  - Clone the source:
 
-        git clone github.com/grookage/qtrouper
+- Clone the source:
 
-  - Build
+      git clone github.com/grookage/qtrouper
 
-        mvn install
+- Build
+
+      mvn install
 
 QTrouper provides the following capabilities
-  - Create a hierarchy of retry and sideline for queue
-  - Configure the number of times and the backoff on the retry queue
-  - Enable consumption on the sideline queue or otherwise.
-  - Queue the entire context with intermediate objects, so long as they are serializable.
-  - An interface for consumption of main queue and sideline queue messages
+
+- Create a hierarchy of retry and sideline for queue
+- Configure the number of times and the backoff on the retry queue
+- Enable consumption on the sideline queue or otherwise.
+- Queue the entire context with intermediate objects, so long as they are serializable.
+- An interface for consumption of main queue and sideline queue messages
 
 # Key Concepts
 
-  - Main Queue      : A queue on which the primary action is performed. Define a consumer on this queue by extending the Trouper class and implementing its process method.
-  - Retry Queue     : A retry queue is not visible to the user. It is responsible for expiring a message and dead lettering into main queue till the maxRetryCount is not breached.
-  - Sideline Queue  : A sideline queue on which the tertiary action is performed. Define a consumer on this queue by extending the Trouper class and implementing its processSideline method
-  - QueueContex     : A Map to a key + a serializable object that gets enqueued in the queues
-  - Trouper         : The Trouper is the queueing interface to provide main_queue, retry_queue and sideline_queue implementations for any call to action.
-
+- Main Queue      : A queue on which the primary action is performed. Define a consumer on this
+  queue by extending the Trouper class and implementing its process method.
+- Retry Queue     : A retry queue is not visible to the user. It is responsible for expiring a
+  message and dead lettering into main queue till the maxRetryCount is not breached.
+- Sideline Queue  : A sideline queue on which the tertiary action is performed. Define a consumer on
+  this queue by extending the Trouper class and implementing its processSideline method
+- QueueContex     : A Map to a key + a serializable object that gets enqueued in the queues
+- Trouper         : The Trouper is the queueing interface to provide main_queue, retry_queue and
+  sideline_queue implementations for any call to action.
 
 > The overriding design goal for qtrouper model
 > is to make it as ready as possible to onboard a new message processor.
@@ -84,14 +89,14 @@ static class SampleConfiguration extends Configuration{
 
 ```
 
-## Sample Actor
+## Sample Trouper
 
 ```
 
-static class QueueingActor extends QTrouper<QueueContext> {
+static class TestTrouper extends QTrouper<QueueContext> {
 
         @Inject
-        public SymphonyActor(QueueConfiguration consumerConfiguration, RabbitConnection rabbitConnection) {
+        public TestTrouper(QueueConfiguration consumerConfiguration, RabbitConnection rabbitConnection) {
             super("sampleQueue",
                     consumerConfiguration,
                     rabbitConnection,
@@ -127,16 +132,14 @@ LICENSE
 
 Copyright 2019 Koushik R <rkoushik.14@gmail.com>.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions and limitations under the
+License.
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,12 @@
         <!--Sonar properties-->
         <sonar.organization>grookage</sonar.organization>
         <testcontainer.rabbitmq.version>1.16.2</testcontainer.rabbitmq.version>
+
+        <sonar.coverage.exclusions>
+            **com/grookage/qtrouper/Trouper.java,
+            **com/grookage/qtrouper/TrouperBundle.java
+            **com/grookage/qtrouper/core/rabbit/RabbitConnection.java
+        </sonar.coverage.exclusions>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,200 +1,182 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.grookage.qtrouper</groupId>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <artifactId>qtrouper</artifactId>
-    <version>1.0.1</version>
-    <packaging>jar</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                    <release>11</release>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <artifactId>asm</artifactId>
+                        <groupId>org.ow2.asm</groupId>
+                        <version>7.2</version>
+                    </dependency>
+                </dependencies>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>3.8.1</version>
+            </plugin>
 
-    <name>qtrouper</name>
-    <url>https://github.com/grookage/qtrouper</url>
-    <description>A simple interface to provide a java DSL atop RMQ, for message processing with programmable retries</description>
-    <inceptionYear>2015</inceptionYear>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <id>test</id>
+                        <phase>test</phase>
+                    </execution>
+                </executions>
+                <version>2.19.1</version>
+            </plugin>
 
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
+            <plugin>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <version>3.0.3</version>
+            </plugin>
 
-    <scm>
-        <connection>scm:git:https://github.com/grookage/qtrouper.git</connection>
-        <developerConnection>scm:git:https://github.com/grookage/qtrouper.git</developerConnection>
-        <tag>HEAD</tag>
-        <url>https://github.com/grookage/qtrouper.git</url>
-    </scm>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <id>attach-sources</id>
+                    </execution>
+                </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <id>attach-javadocs</id>
+                    </execution>
+                </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>3.3.0</version>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <artifactId>lombok</artifactId>
+            <groupId>org.projectlombok</groupId>
+            <scope>provided</scope>
+            <version>${lombok.version}</version>
+        </dependency>
+        <dependency>
+            <artifactId>dropwizard-core</artifactId>
+            <groupId>io.dropwizard</groupId>
+            <scope>provided</scope>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
+            <artifactId>junit</artifactId>
+            <groupId>junit</groupId>
+            <scope>test</scope>
+            <version>${junit.version}</version>
+        </dependency>
+        <dependency>
+            <artifactId>dropwizard-testing</artifactId>
+            <groupId>io.dropwizard</groupId>
+            <scope>test</scope>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
+            <artifactId>mockito-core</artifactId>
+            <groupId>org.mockito</groupId>
+            <scope>test</scope>
+            <version>${mockito.version}</version>
+        </dependency>
 
+        <dependency>
+            <artifactId>reflections</artifactId>
+            <groupId>org.reflections</groupId>
+            <version>${reflections.version}</version>
+        </dependency>
+
+        <!-- RabbitMQ -->
+        <dependency>
+            <artifactId>amqp-client</artifactId>
+            <groupId>com.rabbitmq</groupId>
+            <version>${amqp.version}</version>
+        </dependency>
+    </dependencies>
+    <description>A simple interface to provide a java DSL atop RMQ, for message processing with
+        programmable retries
+    </description>
     <developers>
         <developer>
+            <email>rkoushik.14@gmail.com</email>
             <id>koushikr</id>
             <name>Koushik Ramachandra</name>
-            <email>rkoushik.14@gmail.com</email>
             <roles>
                 <role>owner</role>
                 <role>developer</role>
             </roles>
         </developer>
         <developer>
+            <email>chaitanyachavali7@gmail.com</email>
             <id>chaitanyachavali</id>
             <name>Chaitanya Reddy</name>
-            <email>chaitanyachavali7@gmail.com</email>
             <roles>
                 <role>developer</role>
             </roles>
         </developer>
     </developers>
 
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+    <groupId>com.grookage.qtrouper</groupId>
+    <inceptionYear>2015</inceptionYear>
     <issueManagement>
         <system>GitHub Issues</system>
         <url>https://github.com/grookage/qtrouper/issues</url>
     </issueManagement>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>2.0.28</dropwizard.version>
-        <lombok.version>1.18.22</lombok.version>
-        <guava.version>23.0</guava.version>
-        <junit.version>4.13.2</junit.version>
-        <mockito.version>4.2.0</mockito.version>
-        <cglib.version>3.2.5</cglib.version>
-        <amqp.version>5.14.0</amqp.version>
-        <testcontainer.rabbitmq.version>1.16.2</testcontainer.rabbitmq.version>
-        <reflections.version>0.10.2</reflections.version>
-        <!--Jacoco properties-->
-        <jacoco.version>0.8.0</jacoco.version>
-        <jacoco.reportPath>${project.basedir}/../target/jacoco.exec</jacoco.reportPath>
+    <licenses>
+        <license>
+            <comments>A business-friendly OSS license</comments>
+            <distribution>repo</distribution>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
 
-        <!--Sonar properties-->
-        <sonar.organization>grookage</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-    </properties>
+    <modelVersion>4.0.0</modelVersion>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-core</artifactId>
-            <version>${dropwizard.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-testing</artifactId>
-            <version>${dropwizard.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
+    <name>qtrouper</name>
 
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>${reflections.version}</version>
-        </dependency>
-
-        <!-- RabbitMQ -->
-        <dependency>
-            <groupId>com.rabbitmq</groupId>
-            <artifactId>amqp-client</artifactId>
-            <version>${amqp.version}</version>
-        </dependency>
-    </dependencies>
-
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <release>11</release>
-                    <source>11</source>
-                    <target>11</target>
-                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.ow2.asm</groupId>
-                        <artifactId>asm</artifactId>
-                        <version>7.2</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
-                <executions>
-                    <execution>
-                        <id>test</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.3</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <source>11</source>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <packaging>jar</packaging>
 
     <profiles>
         <profile>
-            <id>release</id>
             <activation>
                 <property>
                     <name>release</name>
@@ -204,80 +186,102 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
-                        <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <serverId>ossrh</serverId>
                         </configuration>
+                        <extensions>true</extensions>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <version>1.6.7</version>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
                         <executions>
                             <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
+                                <configuration>
+                                    <executable>gpg</executable>
+                                    <useAgent>true</useAgent>
+                                </configuration>
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
-                                <configuration>
-                                    <useAgent>true</useAgent>
-                                    <executable>gpg</executable>
-                                </configuration>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
                             </execution>
                         </executions>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <version>1.6</version>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>3.0.0-M2</version>
                         <executions>
                             <execution>
-                                <id>enforce-no-snapshots</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
                                 <configuration>
+                                    <fail>true</fail>
                                     <rules>
                                         <requireReleaseDeps>
                                             <message>No Snapshots Allowed!</message>
                                         </requireReleaseDeps>
                                     </rules>
-                                    <fail>true</fail>
                                 </configuration>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <id>enforce-no-snapshots</id>
                             </execution>
                         </executions>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <version>3.0.0-M2</version>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-release-plugin</artifactId>
-                        <version>2.5.3</version>
                         <configuration>
                             <autoVersionSubmodules>true</autoVersionSubmodules>
-                            <useReleaseProfile>false</useReleaseProfile>
-                            <releaseProfiles>release</releaseProfiles>
                             <goals>deploy</goals>
+                            <releaseProfiles>release</releaseProfiles>
+                            <useReleaseProfile>false</useReleaseProfile>
                         </configuration>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <version>2.5.3</version>
                     </plugin>
                 </plugins>
             </build>
+            <id>release</id>
         </profile>
     </profiles>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
+    <properties>
+        <amqp.version>5.14.0</amqp.version>
+        <cglib.version>3.2.5</cglib.version>
+        <dropwizard.version>2.0.28</dropwizard.version>
+        <guava.version>23.0</guava.version>
+        <jacoco.reportPath>${project.basedir}/../target/jacoco.exec</jacoco.reportPath>
+        <jacoco.version>0.8.0</jacoco.version>
+        <junit.version>4.13.2</junit.version>
+        <lombok.version>1.18.22</lombok.version>
+        <mockito.version>4.2.0</mockito.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--Jacoco properties-->
+        <reflections.version>0.10.2</reflections.version>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+
+        <!--Sonar properties-->
+        <sonar.organization>grookage</sonar.organization>
+        <testcontainer.rabbitmq.version>1.16.2</testcontainer.rabbitmq.version>
+    </properties>
+
+
+    <scm>
+        <connection>scm:git:https://github.com/grookage/qtrouper.git</connection>
+        <developerConnection>scm:git:https://github.com/grookage/qtrouper.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/grookage/qtrouper.git</url>
+    </scm>
+
+    <url>https://github.com/grookage/qtrouper</url>
+
+    <version>1.0.2</version>
 
 </project>

--- a/src/main/java/com/grookage/qtrouper/Trouper.java
+++ b/src/main/java/com/grookage/qtrouper/Trouper.java
@@ -365,7 +365,6 @@ public abstract class Trouper<C extends QueueContext> {
                         Trouper<C> trouper,
                         boolean sideline) throws IOException {
             super(channel);
-
             this.clazz = clazz;
             this.trouper = trouper;
             this.sideline = sideline;

--- a/src/main/java/com/grookage/qtrouper/TrouperBundle.java
+++ b/src/main/java/com/grookage/qtrouper/TrouperBundle.java
@@ -36,37 +36,49 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public abstract class TrouperBundle<T extends Configuration> implements ConfiguredBundle<T> {
 
-    public abstract RabbitConfiguration getRabbitConfiguration(T configuration);
     @Getter
     private RabbitConnection rabbitConnection;
 
+    public abstract RabbitConfiguration getRabbitConfiguration(T configuration);
+
     /**
      * Sets the objectMapper properties and initializes RabbitConnection, along with its health check
-     * @param configuration     {@link T}               The typed configuration against which the said TrouperBundle is initialized
-     * @param environment       {@link Environment}     The dropwizard environment object.
+     *
+     * @param configuration {@link T}               The typed configuration against which the said TrouperBundle is
+     * initialized
+     * @param environment {@link Environment}     The dropwizard environment object.
      */
     @Override
-    public void run(T configuration, Environment environment){
-        environment.getObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-        environment.getObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        environment.getObjectMapper().configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-        environment.getObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        environment.getObjectMapper().configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
-        environment.getObjectMapper().configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true);
+    public void run(T configuration,
+                    Environment environment) {
+        environment.getObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        environment.getObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        environment.getObjectMapper()
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        environment.getObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        environment.getObjectMapper()
+                .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        environment.getObjectMapper()
+                .configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true);
         SerDe.init(environment.getObjectMapper());
         rabbitConnection = new RabbitConnection(getRabbitConfiguration(configuration), environment.metrics());
-        environment.lifecycle().manage(new Managed() {
-            @Override
-            public void start() {
-                rabbitConnection.start();
-            }
+        environment.lifecycle()
+                .manage(new Managed() {
+                    @Override
+                    public void start() {
+                        rabbitConnection.start();
+                    }
 
-            @Override
-            public void stop() {
-                rabbitConnection.stop();
-            }
-        });
-        environment.healthChecks().register("qTrouper-health-check", new TrouperHealthCheck(rabbitConnection));
+                    @Override
+                    public void stop() {
+                        rabbitConnection.stop();
+                    }
+                });
+        environment.healthChecks()
+                .register("qTrouper-health-check", new TrouperHealthCheck(rabbitConnection));
     }
 
     @Override

--- a/src/main/java/com/grookage/qtrouper/core/config/QueueConfiguration.java
+++ b/src/main/java/com/grookage/qtrouper/core/config/QueueConfiguration.java
@@ -17,11 +17,15 @@ package com.grookage.qtrouper.core.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.*;
-
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 /**
  * @author koushik
@@ -34,6 +38,7 @@ import javax.validation.constraints.Min;
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class QueueConfiguration {
+
     private static final String DEFAULT_NAMESPACE = "qtrouper";
     @Builder.Default
     private String namespace = DEFAULT_NAMESPACE;
@@ -51,9 +56,11 @@ public class QueueConfiguration {
     private RetryConfiguration retry;
     @Valid
     private SidelineConfiguration sideline;
+    @Builder.Default
+    private int maxPriority = 0;
 
     @JsonIgnore
-    public boolean isConsumerEnabled(){
+    public boolean isConsumerEnabled() {
         return !consumerDisabled;
     }
 

--- a/src/main/java/com/grookage/qtrouper/core/config/RetryConfiguration.java
+++ b/src/main/java/com/grookage/qtrouper/core/config/RetryConfiguration.java
@@ -16,7 +16,12 @@
 package com.grookage.qtrouper.core.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 /**
  * @author koushik
@@ -29,6 +34,7 @@ import lombok.*;
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RetryConfiguration {
+
     @Builder.Default
     private boolean enabled = true;
     private long ttlMs;

--- a/src/main/java/com/grookage/qtrouper/core/config/SidelineConfiguration.java
+++ b/src/main/java/com/grookage/qtrouper/core/config/SidelineConfiguration.java
@@ -16,7 +16,11 @@
 package com.grookage.qtrouper.core.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 /**
  * @author koushik
@@ -28,8 +32,8 @@ import lombok.*;
 @Builder
 @EqualsAndHashCode
 public class SidelineConfiguration {
+
     @Builder.Default
     private boolean enabled = true;
     private int concurrency;
-
 }

--- a/src/main/java/com/grookage/qtrouper/core/healthchecks/TrouperHealthCheck.java
+++ b/src/main/java/com/grookage/qtrouper/core/healthchecks/TrouperHealthCheck.java
@@ -17,18 +17,17 @@ package com.grookage.qtrouper.core.healthchecks;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.grookage.qtrouper.core.rabbit.RabbitConnection;
-import lombok.AllArgsConstructor;
-import lombok.val;
-
-import javax.inject.Singleton;
 import java.io.IOException;
+import javax.inject.Singleton;
+import lombok.AllArgsConstructor;
 
 /**
  * @author koushik
  */
 @Singleton
 @AllArgsConstructor
-public class TrouperHealthCheck extends HealthCheck{
+public class TrouperHealthCheck extends HealthCheck {
+
     private final RabbitConnection rabbitConnection;
 
     @Override

--- a/src/main/java/com/grookage/qtrouper/core/models/QAccessInfo.java
+++ b/src/main/java/com/grookage/qtrouper/core/models/QAccessInfo.java
@@ -15,7 +15,11 @@
  */
 package com.grookage.qtrouper.core.models;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 /**
  * @author koushik
@@ -26,6 +30,7 @@ import lombok.*;
 @NoArgsConstructor
 @Builder
 public class QAccessInfo {
+
     private boolean idempotencyCheckRequired;
     private int retryCount;
 }

--- a/src/main/java/com/grookage/qtrouper/core/models/QueueContext.java
+++ b/src/main/java/com/grookage/qtrouper/core/models/QueueContext.java
@@ -19,11 +19,15 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Strings;
 import com.grookage.qtrouper.core.exceptions.TrouperExceptions;
 import com.grookage.qtrouper.utils.SerDe;
-import lombok.*;
-
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * @author koushik
@@ -35,29 +39,45 @@ import java.util.Map;
 @ToString
 @Builder
 @SuppressWarnings("unused")
-public class QueueContext implements Serializable{
+public class QueueContext implements Serializable {
+
     private String serviceReference;
     @Builder.Default
     private Map<String, Object> data = new HashMap<>();
+    @Builder.Default
+    private int messagePriority = 0;
 
-    public <T> void addContext(Class<T> klass, T value) {
-        addContext(klass.getSimpleName().toUpperCase(), value);
+    public <T> void addContext(Class<T> klass,
+                               T value) {
+        addContext(klass.getSimpleName()
+                .toUpperCase(), value);
     }
 
     @JsonIgnore
     public <T> T getContext(Class<T> tClass) {
-        return getContext(tClass.getSimpleName().toUpperCase(), tClass);
+        return getContext(tClass.getSimpleName()
+                .toUpperCase(), tClass);
     }
 
-    public <T> void addContext(String key, T value) {
-        if (Strings.isNullOrEmpty(key.toUpperCase()))
+    public <T> void addContext(String key,
+                               T value) {
+        if (Strings.isNullOrEmpty(key.toUpperCase())) {
             TrouperExceptions.illegalArgument("Invalid key for context data. Key cannot be null/empty");
+        }
         this.data.put(key.toUpperCase(), value);
     }
 
     @JsonIgnore
-    public <T> T getContext(String key, Class<T> tClass) {
+    public <T> T getContext(String key,
+                            Class<T> tClass) {
         final var value = this.data.get(key.toUpperCase());
-        return null == value ? null : SerDe.mapper().convertValue(value, tClass);
+        return null == value
+               ? null
+               : SerDe.mapper()
+                       .convertValue(value, tClass);
+    }
+
+    public void resetMessagePriority() {
+        this.setMessagePriority(0);
     }
 }

--- a/src/main/java/com/grookage/qtrouper/core/rabbit/RabbitBroker.java
+++ b/src/main/java/com/grookage/qtrouper/core/rabbit/RabbitBroker.java
@@ -15,15 +15,14 @@
  */
 package com.grookage.qtrouper.core.rabbit;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * @author koushik
@@ -33,6 +32,7 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 @Builder
 public class RabbitBroker {
+
     @NotEmpty
     @NotNull
     private String host;

--- a/src/main/java/com/grookage/qtrouper/core/rabbit/RabbitConfiguration.java
+++ b/src/main/java/com/grookage/qtrouper/core/rabbit/RabbitConfiguration.java
@@ -16,14 +16,13 @@
 package com.grookage.qtrouper.core.rabbit;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
-import java.util.List;
 
 /**
  * @author koushik
@@ -34,6 +33,7 @@ import java.util.List;
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RabbitConfiguration {
+
     @NotNull
     @NotEmpty
     private List<RabbitBroker> brokers;

--- a/src/test/java/com/grookage/qtrouper/core/config/QueueConfigurationTest.java
+++ b/src/test/java/com/grookage/qtrouper/core/config/QueueConfigurationTest.java
@@ -15,25 +15,27 @@
  */
 package com.grookage.qtrouper.core.config;
 
-import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class QueueConfigurationTest {
 
-  @Test
-  public void testQueueConfigurationDefaultViaConstructor() {
-      final var queueConfiguration = new QueueConfiguration();
-      Assert.assertFalse(queueConfiguration.isConsumerDisabled());
-      Assert.assertEquals(3, queueConfiguration.getConcurrency());
-      Assert.assertEquals("qtrouper", queueConfiguration.getNamespace());
-  }
+    @Test
+    public void testQueueConfigurationDefaultViaConstructor() {
+        final var queueConfiguration = new QueueConfiguration();
+        Assert.assertFalse(queueConfiguration.isConsumerDisabled());
+        Assert.assertEquals(3, queueConfiguration.getConcurrency());
+        Assert.assertEquals("qtrouper", queueConfiguration.getNamespace());
+        Assert.assertEquals(0, queueConfiguration.getMaxPriority());
+    }
 
-  @Test
-  public void testQueueConfigurationDefaultViaBuilder() {
-      final var queueViaBuilder = QueueConfiguration.builder().build();
-      Assert.assertFalse(queueViaBuilder.isConsumerDisabled());
-      Assert.assertEquals(3, queueViaBuilder.getConcurrency());
-      Assert.assertEquals("qtrouper", queueViaBuilder.getNamespace());
-  }
+    @Test
+    public void testQueueConfigurationDefaultViaBuilder() {
+        final var queueViaBuilder = QueueConfiguration.builder()
+                .build();
+        Assert.assertFalse(queueViaBuilder.isConsumerDisabled());
+        Assert.assertEquals(3, queueViaBuilder.getConcurrency());
+        Assert.assertEquals("qtrouper", queueViaBuilder.getNamespace());
+        Assert.assertEquals(0, queueViaBuilder.getMaxPriority());
+    }
 }

--- a/src/test/java/com/grookage/qtrouper/core/config/QueueConfigurationTest.java
+++ b/src/test/java/com/grookage/qtrouper/core/config/QueueConfigurationTest.java
@@ -27,6 +27,8 @@ public class QueueConfigurationTest {
         Assert.assertEquals(3, queueConfiguration.getConcurrency());
         Assert.assertEquals("qtrouper", queueConfiguration.getNamespace());
         Assert.assertEquals(0, queueConfiguration.getMaxPriority());
+        Assert.assertEquals(1, queueConfiguration.getPrefetchCount());
+        Assert.assertFalse(queueConfiguration.isConsumerDisabled());
     }
 
     @Test
@@ -37,5 +39,8 @@ public class QueueConfigurationTest {
         Assert.assertEquals(3, queueViaBuilder.getConcurrency());
         Assert.assertEquals("qtrouper", queueViaBuilder.getNamespace());
         Assert.assertEquals(0, queueViaBuilder.getMaxPriority());
+        Assert.assertEquals(1, queueViaBuilder.getPrefetchCount());
+        Assert.assertFalse(queueViaBuilder.isConsumerDisabled());
+
     }
 }

--- a/src/test/java/com/grookage/qtrouper/core/models/QueueContextTest.java
+++ b/src/test/java/com/grookage/qtrouper/core/models/QueueContextTest.java
@@ -1,0 +1,25 @@
+package com.grookage.qtrouper.core.models;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grookage.qtrouper.utils.SerDe;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QueueContextTest {
+
+    @Test
+    public void testQueueContext(){
+        SerDe.init(new ObjectMapper());
+        final var queueContext = QueueContext.builder().build();
+        Assert.assertEquals(0, queueContext.getMessagePriority());
+        queueContext.addContext("test", "test");
+        final var returnValue = queueContext.getContext("test", String.class);
+        Assert.assertNotNull(returnValue);
+        Assert.assertEquals("test", returnValue);
+        queueContext.setMessagePriority(10);
+        Assert.assertEquals(10, queueContext.getMessagePriority());
+        queueContext.resetMessagePriority();
+        Assert.assertEquals(0, queueContext.getMessagePriority());
+    }
+}

--- a/styleguide.xml
+++ b/styleguide.xml
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<code_scheme name="GoogleStyle">
+    <AndroidXmlCodeStyleSettings>
+        <option name="USE_CUSTOM_SETTINGS" value="true"/>
+        <option name="LAYOUT_SETTINGS">
+            <value>
+                <option name="INSERT_BLANK_LINE_BEFORE_TAG" value="false"/>
+            </value>
+        </option>
+    </AndroidXmlCodeStyleSettings>
+    <JSCodeStyleSettings>
+        <option name="INDENT_CHAINED_CALLS" value="false"/>
+    </JSCodeStyleSettings>
+    <Objective-C>
+        <option name="INDENT_NAMESPACE_MEMBERS" value="0"/>
+        <option name="INDENT_C_STRUCT_MEMBERS" value="2"/>
+        <option name="INDENT_CLASS_MEMBERS" value="2"/>
+        <option name="INDENT_VISIBILITY_KEYWORDS" value="1"/>
+        <option name="INDENT_INSIDE_CODE_BLOCK" value="2"/>
+        <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true"/>
+        <option name="FUNCTION_PARAMETERS_WRAP" value="5"/>
+        <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5"/>
+        <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5"/>
+        <option name="TEMPLATE_CALL_ARGUMENTS_ALIGN_MULTILINE" value="true"/>
+        <option name="ALIGN_INIT_LIST_IN_COLUMNS" value="false"/>
+        <option name="SPACE_BEFORE_SUPERCLASS_COLON" value="false"/>
+    </Objective-C>
+    <Objective-C-extensions>
+        <class>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod"/>
+        </class>
+        <extensions>
+            <pair header="h" source="cc"/>
+            <pair header="h" source="c"/>
+        </extensions>
+        <file>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl"/>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function"/>
+        </file>
+        <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK"/>
+        <option name="RELEASE_STYLE" value="IVAR"/>
+        <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE"/>
+    </Objective-C-extensions>
+    <Python>
+        <option name="USE_CONTINUATION_INDENT_FOR_ARGUMENTS" value="true"/>
+    </Python>
+    <TypeScriptCodeStyleSettings>
+        <option name="INDENT_CHAINED_CALLS" value="false"/>
+    </TypeScriptCodeStyleSettings>
+    <XML>
+        <option name="XML_ALIGN_ATTRIBUTES" value="false"/>
+        <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
+    </XML>
+    <codeStyleSettings language="CSS">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="ECMA Script Level 4">
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="ALIGN_MULTILINE_FOR" value="false"/>
+        <option name="CALL_PARAMETERS_WRAP" value="1"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="EXTENDS_LIST_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+        <option name="TERNARY_OPERATION_WRAP" value="1"/>
+        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+        <option name="FOR_STATEMENT_WRAP" value="1"/>
+        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+        <option name="IF_BRACE_FORCE" value="3"/>
+        <option name="DOWHILE_BRACE_FORCE" value="3"/>
+        <option name="WHILE_BRACE_FORCE" value="3"/>
+        <option name="FOR_BRACE_FORCE" value="3"/>
+        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    </codeStyleSettings>
+    <codeStyleSettings language="HTML">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+        <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="ALIGN_MULTILINE_RESOURCES" value="false"/>
+        <option name="ALIGN_MULTILINE_FOR" value="false"/>
+        <option name="CALL_PARAMETERS_WRAP" value="1"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="EXTENDS_LIST_WRAP" value="1"/>
+        <option name="THROWS_KEYWORD_WRAP" value="1"/>
+        <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+        <option name="TERNARY_OPERATION_WRAP" value="1"/>
+        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+        <option name="FOR_STATEMENT_WRAP" value="1"/>
+        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+        <option name="WRAP_COMMENTS" value="true"/>
+        <option name="IF_BRACE_FORCE" value="3"/>
+        <option name="DOWHILE_BRACE_FORCE" value="3"/>
+        <option name="WHILE_BRACE_FORCE" value="3"/>
+        <option name="FOR_BRACE_FORCE" value="3"/>
+        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    </codeStyleSettings>
+    <codeStyleSettings language="JSON">
+        <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+        <option name="RIGHT_MARGIN" value="80"/>
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="ALIGN_MULTILINE_FOR" value="false"/>
+        <option name="CALL_PARAMETERS_WRAP" value="1"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+        <option name="TERNARY_OPERATION_WRAP" value="1"/>
+        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+        <option name="FOR_STATEMENT_WRAP" value="1"/>
+        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+        <option name="IF_BRACE_FORCE" value="3"/>
+        <option name="DOWHILE_BRACE_FORCE" value="3"/>
+        <option name="WHILE_BRACE_FORCE" value="3"/>
+        <option name="FOR_BRACE_FORCE" value="3"/>
+        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    </codeStyleSettings>
+    <codeStyleSettings language="PROTO">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+        <option name="RIGHT_MARGIN" value="80"/>
+    </codeStyleSettings>
+    <codeStyleSettings language="protobuf">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+        <option name="RIGHT_MARGIN" value="80"/>
+    </codeStyleSettings>
+    <codeStyleSettings language="Python">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+        <option name="RIGHT_MARGIN" value="80"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    </codeStyleSettings>
+    <codeStyleSettings language="SASS">
+        <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="SCSS">
+        <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+        <arrangement>
+            <rules>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>xmlns:android</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>^$</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>xmlns:.*</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>^$</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:id</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>style</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>^$</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>^$</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:.*Style</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_width</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_height</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_weight</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_margin</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_marginTop</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_marginBottom</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_marginStart</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_marginEnd</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_marginLeft</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_marginRight</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:layout_.*</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:padding</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:paddingTop</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:paddingBottom</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:paddingStart</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:paddingEnd</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:paddingLeft</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*:paddingRight</NAME>
+                                <XML_ATTRIBUTE/>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/apk/res-auto</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*</NAME>
+                                <XML_NAMESPACE>http://schemas.android.com/tools</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+                <section>
+                    <rule>
+                        <match>
+                            <AND>
+                                <NAME>.*</NAME>
+                                <XML_NAMESPACE>.*</XML_NAMESPACE>
+                            </AND>
+                        </match>
+                        <order>BY_NAME</order>
+                    </rule>
+                </section>
+            </rules>
+        </arrangement>
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+            <option name="TAB_SIZE" value="2"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="ObjectiveC">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+        </indentOptions>
+        <option name="RIGHT_MARGIN" value="80"/>
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+        <option name="BLANK_LINES_BEFORE_IMPORTS" value="0"/>
+        <option name="BLANK_LINES_AFTER_IMPORTS" value="0"/>
+        <option name="BLANK_LINES_AROUND_CLASS" value="0"/>
+        <option name="BLANK_LINES_AROUND_METHOD" value="0"/>
+        <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0"/>
+        <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="false"/>
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+        <option name="FOR_STATEMENT_WRAP" value="1"/>
+        <option name="ASSIGNMENT_WRAP" value="1"/>
+    </codeStyleSettings>
+    <option name="OTHER_INDENT_OPTIONS">
+        <value>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="2"/>
+            <option name="USE_TAB_CHARACTER" value="false"/>
+            <option name="SMART_TABS" value="false"/>
+            <option name="LABEL_INDENT_SIZE" value="0"/>
+            <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+            <option name="USE_RELATIVE_INDENTS" value="false"/>
+        </value>
+    </option>
+    <option name="INSERT_INNER_CLASS_IMPORTS" value="true"/>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
+    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value/>
+    </option>
+    <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+            <emptyLine/>
+            <package name="" static="true" withSubpackages="true"/>
+            <package name="" static="false" withSubpackages="true"/>
+        </value>
+    </option>
+    <option name="RIGHT_MARGIN" value="100"/>
+    <option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
+    <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
+    <option name="JD_P_AT_EMPTY_LINES" value="false"/>
+    <option name="JD_KEEP_EMPTY_PARAMETER" value="false"/>
+    <option name="JD_KEEP_EMPTY_EXCEPTION" value="false"/>
+    <option name="JD_KEEP_EMPTY_RETURN" value="false"/>
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="0"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
+    <option name="THROWS_KEYWORD_WRAP" value="1"/>
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="WRAP_COMMENTS" value="true"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
+</code_scheme>


### PR DESCRIPTION
This refers to the improvement listed [here](https://github.com/grookage/qtrouper/issues/2)

Added PQ support to Trouper, in accordance with [RMQ Priority Support](https://www.rabbitmq.com/priority.html)

The idea to have a strategy to figure out what to do with retries and sidelines was considered during the addition and has been omitted for the following reasons. 

- TTL timers aren't aware of priorities. Messages are dead lettered only when they reach queue head.
- This causes issues when trying to reach the queueHead and the interplay between TTL and PQ becomes an issue. 

So during a retry, the priority specified in the [QueueContext](https://github.com/grookage/qtrouper/blob/master/src/main/java/com/grookage/qtrouper/core/models/QueueContext.java) is captured into a header and preserved during the dead-lettering onto the MQ, the idea of having various strategies to increase, decrease the priority has been considered and omitted for the release - Future scope may include, having a backoff factor to priority on every retry - within the boundaries of maxPriority, needs a retryCount<>PriorityAdjustment function - open to MR if someone chooses to submit. 

Sideline Publishes will happen with priority in accordance to the MQ priority supplied. 

