### PR TITLE
Honour Dropped Exceptions For Retries

### DIFF
--- a/src/main/java/com/grookage/qtrouper/Trouper.java
+++ b/src/main/java/com/grookage/qtrouper/Trouper.java
@@ -133,6 +133,7 @@ public abstract class Trouper<C extends QueueContext> {
             }
         } catch (Exception ex) {
             log.error("Exception while processing the queueContext {}", queueContext, ex);
+            throw ex;
         }
 
         final var retry = config.getRetry();

--- a/src/test/java/com/grookage/qtrouper/core/config/HandlerTest.java
+++ b/src/test/java/com/grookage/qtrouper/core/config/HandlerTest.java
@@ -124,7 +124,7 @@ public class HandlerTest {
     }
 
     @Test
-    public void testBasicRejectAndSidelineWhenTrouperProcessThrowUnknownException() throws IOException {
+    public void testBasicAckAndSidelineWhenTrouperProcessThrowUnknownException() throws IOException {
 
         final var exceptionInterface = mock(ExceptionInterface.class);
         final var testHandler = getHandlerAfterSettingUp(mainQueueHandlerTag, exceptionInterface);
@@ -135,9 +135,9 @@ public class HandlerTest {
                 .writeValueAsBytes(QueueContext.builder()
                         .build()));
 
-        verify(channel).basicReject(deliveryTagCaptor.capture(), boolCaptor.capture());
+        verify(channel).basicAck(deliveryTagCaptor.capture(), boolCaptor.capture());
         Assert.assertEquals(deliveryTag, deliveryTagCaptor.getValue());
-        Assert.assertEquals(true, boolCaptor.getValue());
+        Assert.assertEquals(false, boolCaptor.getValue());
         verify(channel, times(1)).basicPublish(any(), any(), any(), any());
     }
 
@@ -156,7 +156,6 @@ public class HandlerTest {
         verify(channel).basicAck(deliveryTagCaptor.capture(), boolCaptor.capture());
         Assert.assertEquals(deliveryTag, deliveryTagCaptor.getValue());
         Assert.assertEquals(false, boolCaptor.getValue());
-        verify(channel, times(1)).basicPublish(any(), any(), any(), any());
     }
 
     @Test
@@ -285,7 +284,6 @@ public class HandlerTest {
         verify(channel).basicAck(deliveryTagCaptor.capture(), boolCaptor.capture());
         Assert.assertEquals(deliveryTag, deliveryTagCaptor.getValue());
         Assert.assertEquals(false, boolCaptor.getValue());
-        verify(channel, times(1)).basicPublish(any(), any(), any(), any());
     }
 
     interface ExceptionInterface {


### PR DESCRIPTION
**Problem** 
Dropped exceptions are not honoured, and retry happens inevitably. 
**Issue**
The handler is catching the exception thrown by the process method followed by the retry mechanism. 
**Solution**
If the consumer is throwing the exception, floating it to the caller method where the dropped exception logic kicks in.